### PR TITLE
Add GCP auth at apply and simplify check-secure-estimate workflow

### DIFF
--- a/.github/workflows/tf-check-secure-estimate.yml
+++ b/.github/workflows/tf-check-secure-estimate.yml
@@ -10,8 +10,6 @@ permissions:
   pull-requests: write
 
 env:
-  AWS_ACCESS_KEY_ID : "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY : "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
   TF_ROOT : "."
   
 jobs:
@@ -32,7 +30,7 @@ jobs:
 
     # Initialize a new or existing Terraform working directory
     - name: Terraform Init
-      run: terraform init
+      run: terraform init -backend=false
 
     # Validate terraform files
     - name: Terraform Validate
@@ -98,14 +96,9 @@ jobs:
       with:
         terraform_wrapper: false
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
-      run: terraform init
+      run: terraform init -backend=false
 
-    # Plan change 
-    - name: Terraform Plan
-      run: terraform plan
-  
     - name: Setup Infracost
       uses: infracost/actions/setup@v2
       with:

--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -14,6 +14,7 @@ permissions:
 env:
   AWS_ACCESS_KEY_ID : "${{ secrets.AWS_ACCESS_KEY_ID }}"
   AWS_SECRET_ACCESS_KEY : "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  GOOGLE_APPLICATION_CREDENTIALS  : /tmp/gcp.creds
   TF_ROOT : "."
 
 jobs:
@@ -27,6 +28,13 @@ jobs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 
     steps:
+    # Set-up Google authentication if configured
+    - name: Set-up GCP auth
+      if: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_CONTENT != '' }}
+      run: cat - <<<"${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}" > "$GOOGLE_APPLICATION_CREDENTIALS"
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_CONTENT }}"
+
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v3
@@ -119,6 +127,13 @@ jobs:
     needs: [terraform-plan]
     
     steps:
+    # Set-up Google authentication if configured
+    - name: Set-up GCP auth
+      if: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_CONTENT != '' }}
+      run: cat - <<<"${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}" > "$GOOGLE_APPLICATION_CREDENTIALS"
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_CONTENT }}"
+
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v3


### PR DESCRIPTION
Running `terraform plan` is not required to get estimates (and infracost runs init on its own if needed), and not running it makes it so that the whole workflow does not need to expose authentication information, hence the removal of `AWS_*` env.

Adding GCP support for deployments via the `GOOGLE_APPLICATION_CREDENTIALS` file path. Repository owners should define `secrets.GOOGLE_APPLICATION_CREDENTIALS_CONTENT` with the content of their Google authentication file (Related terraform documentation: https://registry.terraform.io/providers/hashicorp/google/latest/docs/guides/provider_reference#running-terraform-outside-of-google-cloud ). If the secret is not defined, the step is explicitly skipped and no file is created.
