### PR TITLE
Features/reusable workflows and doc

### DIFF
--- a/.github/workflows/on_pull_request.yml
+++ b/.github/workflows/on_pull_request.yml
@@ -1,0 +1,32 @@
+name: 'Pull Request handler'
+
+on:
+  pull_request:
+
+#Special permissions required for OIDC authentication
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+  
+jobs:
+  terraform-check-code:
+    uses: ./.github/workflows/tf-lint.yml
+
+  terraform-doc-check:
+    needs: terraform-check-code
+    uses: ./.github/workflows/tf-doc.yml
+
+  terraform-secu-scan-tfsec:
+    needs: terraform-check-code
+    uses: ./.github/workflows/tf-sec.yml
+
+  terraform-estimate:
+    needs: terraform-secu-scan-tfsec
+    if: |
+      always() &&
+      contains(needs.*.result, 'success')
+    uses: ./.github/workflows/tf-estimate.yml
+    secrets:
+      INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
+

--- a/.github/workflows/tf-check-secure-estimate.yml
+++ b/.github/workflows/tf-check-secure-estimate.yml
@@ -10,8 +10,6 @@ permissions:
   pull-requests: write
 
 env:
-  AWS_ACCESS_KEY_ID : "${{ secrets.AWS_ACCESS_KEY_ID }}"
-  AWS_SECRET_ACCESS_KEY : "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
   TF_ROOT : "."
   
 jobs:
@@ -32,7 +30,7 @@ jobs:
 
     # Initialize a new or existing Terraform working directory
     - name: Terraform Init
-      run: terraform init
+      run: terraform init -backend=false
 
     # Validate terraform files
     - name: Terraform Validate
@@ -98,14 +96,9 @@ jobs:
       with:
         terraform_wrapper: false
 
-    # Initialize a new or existing Terraform working directory by creating initial files, loading any remote state, downloading modules, etc.
     - name: Terraform Init
-      run: terraform init
+      run: terraform init -backend=false
 
-    # Plan change 
-    - name: Terraform Plan
-      run: terraform plan
-  
     - name: Setup Infracost
       uses: infracost/actions/setup@v2
       with:

--- a/.github/workflows/tf-doc.yml
+++ b/.github/workflows/tf-doc.yml
@@ -1,0 +1,64 @@
+name: 'Terraform Docs'
+
+on:
+  workflow_call:
+    inputs:
+      commit:
+        description: "Whether the changes should be committed"
+        default: false
+        required: false
+        type: boolean
+
+permissions:
+  id-token: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  terraform-doc:
+    name: 'Generate TF Doc'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout PR branch
+      uses: actions/checkout@v3
+
+    - name: Render terraform docs
+      uses: terraform-docs/gh-actions@main
+      id: terraform-docs
+      with:
+        working-dir: .
+        output-file: README.md
+        output-method: inject
+        git-push: ${{ inputs.commit }}
+
+    - name: Prepare PR message
+      run: |
+        baseline="$([[ "${{ inputs.commit }}" = "true" ]] && echo "HEAD~" || echo "HEAD")"
+
+        # TODO: debug, remove
+        echo "${baseline}|||${{ inputs.commit}}|||${{ steps.terraform-docs.outputs.num_changed }}"
+
+        if [ "${{ steps.terraform-docs.outputs.num_changed }}" -eq 0 ] || diff_content="$(git diff --exit-code "${baseline}" README.md)"; then
+          echo "README.md is up to date." >/tmp/README_diff
+          exit 0
+        else
+          cat - >/tmp/README_diff << EOF
+        README.md changes:
+
+        \`\`\`patch
+        ${diff_content}
+        \`\`\`
+        EOF
+
+          # error-out if changes were not committed
+          [[ "${{ inputs.commit }}" = "true" ]]
+          exit "$?"
+        fi
+
+    - name: Update PR comment
+      uses: thollander/actions-comment-pull-request@v2
+      if: ${{ ( success() || failure() ) && github.event_name == 'pull_request' }}
+      with:
+        filePath: /tmp/README_diff
+        comment_tag: documentation_status

--- a/.github/workflows/tf-estimate.yml
+++ b/.github/workflows/tf-estimate.yml
@@ -1,9 +1,12 @@
-name: 'Terraform Check-Secure-Estimate'
+name: Terraform Cost Estimate
 
 on:
-  pull_request:
+  workflow_call:
+    secrets:
+      INFRACOST_API_KEY:
+        description: The key to use when connecting to the infracost API
+        required: true
 
-#Special permissions required for OIDC authentication
 permissions:
   id-token: write
   contents: read
@@ -11,77 +14,9 @@ permissions:
 
 env:
   TF_ROOT : "."
-  
+
 jobs:
-  terraform-check-code:
-    name: 'TF Validate code'
-    runs-on: ubuntu-latest
-
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    # Install the latest version of Terraform CLI
-    - name: Setup Terraform
-      uses: hashicorp/setup-terraform@v2
-      with:
-        terraform_wrapper: false
-
-    # Initialize a new or existing Terraform working directory
-    - name: Terraform Init
-      run: terraform init -backend=false
-
-    # Validate terraform files
-    - name: Terraform Validate
-      run: terraform validate
-
-    # Checks that all Terraform configuration files adhere to a canonical format
-    - name: Terraform Check Format
-      run: terraform fmt -check -recursive
-    
-    ## TFLint installation and configuration
-    - uses: actions/cache@v3
-      name: TFLint - Cache plugin dir
-      with:
-        path: ~/.tflint.d/plugins
-        key: ubuntu-latest-tflint-${{ hashFiles('.tflint.hcl') }}
-
-    - uses: terraform-linters/setup-tflint@v3
-      name: TFLint - Setup
-      with:
-        tflint_version: latest
-
-    - name: TFLint - Show version
-      run: tflint --version
-
-    - name: TFLint - Initiate
-      run: tflint --init
-      env:
-        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
-        GITHUB_TOKEN: ${{ github.token }}
-
-    - name: TFLint - Execute
-      run: tflint -f compact
-
-  terraform-secu-scan-tfsec:
-    needs: terraform-check-code
-    name: 'TF Security Scan'
-    runs-on: ubuntu-latest
-
-    steps:
-    # Checkout the repository to the GitHub Actions runner
-    - name: Checkout PR branch
-      uses: actions/checkout@v3
-    # Perform a security scan of the terraform code using TFsec
-    - name: Run TFsec scan
-      uses: aquasecurity/tfsec-action@v1.0.0
-
-  terraform-plan-estimate:
-    needs: terraform-secu-scan-tfsec
-    if: |
-      always() &&
-      contains(needs.*.result, 'success')
+  terraform-estimate:
     name: 'TF Estimate Cost and Plan'
     runs-on: ubuntu-latest
 
@@ -143,4 +78,3 @@ jobs:
                                  --github-token=${{github.token}} \
                                  --pull-request=${{github.event.pull_request.number}} \
                                  --behavior=update
-

--- a/.github/workflows/tf-lint.yml
+++ b/.github/workflows/tf-lint.yml
@@ -1,0 +1,59 @@
+name: 'Terraform Lint'
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-lint:
+    name: 'TF Validate code'
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    # Install the latest version of Terraform CLI
+    - name: Setup Terraform
+      uses: hashicorp/setup-terraform@v2
+      with:
+        terraform_wrapper: false
+
+    # Initialize a new or existing Terraform working directory
+    - name: Terraform Init
+      run: terraform init -backend=false
+
+    # Validate terraform files
+    - name: Terraform Validate
+      run: terraform validate
+
+    # Checks that all Terraform configuration files adhere to a canonical format
+    - name: Terraform Check Format
+      run: terraform fmt -check -recursive
+    
+    ## TFLint installation and configuration
+    - uses: actions/cache@v3
+      name: TFLint - Cache plugin dir
+      with:
+        path: ~/.tflint.d/plugins
+        key: ubuntu-latest-tflint-${{ hashFiles('.tflint.hcl') }}
+
+    - uses: terraform-linters/setup-tflint@v3
+      name: TFLint - Setup
+      with:
+        tflint_version: latest
+
+    - name: TFLint - Show version
+      run: tflint --version
+
+    - name: TFLint - Initiate
+      run: tflint --init
+      env:
+        # https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting
+        GITHUB_TOKEN: ${{ github.token }}
+
+    - name: TFLint - Execute
+      run: tflint -f compact

--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -14,6 +14,7 @@ permissions:
 env:
   AWS_ACCESS_KEY_ID : "${{ secrets.AWS_ACCESS_KEY_ID }}"
   AWS_SECRET_ACCESS_KEY : "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  GOOGLE_APPLICATION_CREDENTIALS  : /tmp/gcp.creds
   TF_ROOT : "."
 
 jobs:
@@ -27,6 +28,13 @@ jobs:
       tfplanExitCode: ${{ steps.tf-plan.outputs.exitcode }}
 
     steps:
+    # Set-up Google authentication if configured
+    - name: Set-up GCP auth
+      if: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_CONTENT != '' }}
+      run: cat - <<<"${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}" > "$GOOGLE_APPLICATION_CREDENTIALS"
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_CONTENT }}"
+
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v3
@@ -119,6 +127,13 @@ jobs:
     needs: [terraform-plan]
     
     steps:
+    # Set-up Google authentication if configured
+    - name: Set-up GCP auth
+      if: ${{ env.GOOGLE_APPLICATION_CREDENTIALS_CONTENT != '' }}
+      run: cat - <<<"${GOOGLE_APPLICATION_CREDENTIALS_CONTENT}" > "$GOOGLE_APPLICATION_CREDENTIALS"
+      env:
+        GOOGLE_APPLICATION_CREDENTIALS_CONTENT: "${{ secrets.GOOGLE_APPLICATION_CREDENTIALS_CONTENT }}"
+
     # Checkout the repository to the GitHub Actions runner
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/tf-plan-apply.yml
+++ b/.github/workflows/tf-plan-apply.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - main
+  workflow_dispatch:
 
 #Special permissions required for OIDC authentication
 permissions:

--- a/.github/workflows/tf-sec.yml
+++ b/.github/workflows/tf-sec.yml
@@ -1,0 +1,20 @@
+name: 'Terraform Security Scan'
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-secu-scan:
+    name: 'TF Security Scan'
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checkout the repository to the GitHub Actions runner
+    - name: Checkout PR branch
+      uses: actions/checkout@v3
+    # Perform a security scan of the terraform code using TFsec
+    - name: Run TFsec scan
+      uses: aquasecurity/tfsec-action@v1.0.0

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ CD Content:
 
 Works with Cloud Provider below:
   - AWS
+
+<!-- BEGIN_TF_DOCS -->
+The generated module documentation will be here.
+<!-- END_TF_DOCS -->


### PR DESCRIPTION
Split the main PR workflow into several independant reusable workflows. Said reusable workflows may be copied in a independant repository to allow for parallel maintainance of several repositories' workflows.
In such a case, the new `on_pull_request.yml` workflow should be updated to point toward the reference repository (private repositories will need specific configuration to enable sharing, see https://docs.github.com/en/actions/using-workflows/reusing-workflows#access-to-reusable-workflows )

Also adds a job that ensures that the documentation is up-to-date. Part of the shell sheganigans occuring in the step `Prepare PR message` is due to the fact that the terraform-docs step adds updated files to staging even if it is not configured to commit them. The doc workflow call in `on_pull_request.yml` may also be set to commit documentation changes by setting the `commit` input to `true`.

Note that this PR also includes changes from #1
